### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,8 @@ jobs:
           name: Release v${{ steps.gitversion.outputs.semVer }}
           generateReleaseNotes: true
           body:
-            Release ${{ steps.gitversion.outputs.semVer }} of ${{ github.event.repository.name }}
+            Release ${{ steps.gitversion.outputs.semVer }} of ${{
+            github.event.repository.name }}
 
       - name: Create Release (latest)
         uses: ncipollo/release-action@v1.20.0
@@ -107,4 +108,5 @@ jobs:
           name: Release v${{ steps.gitversion.outputs.semVer }}
           generateReleaseNotes: true
           body:
-            Release ${{ steps.gitversion.outputs.semVer }} of ${{ github.event.repository.name }}
+            Release ${{ steps.gitversion.outputs.semVer }} of ${{
+            github.event.repository.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         id: gitversion
         uses: gittools/actions/gitversion/execute@v4.1.0
 
-      - name: Create Release
+      - name: Create Release (tag)
         uses: ncipollo/release-action@v1.20.0
         with:
           allowUpdates: false
@@ -94,5 +94,17 @@ jobs:
           name: Release v${{ steps.gitversion.outputs.semVer }}
           generateReleaseNotes: true
           body:
-            Release ${{ steps.gitversion.outputs.semVer }} of ${{
-            github.event.repository.name }}
+            Release ${{ steps.gitversion.outputs.semVer }} of ${{ github.event.repository.name }}
+
+      - name: Create Release (latest)
+        uses: ncipollo/release-action@v1.20.0
+        with:
+          allowUpdates: true
+          skipIfReleaseExists: false
+          draft: false
+          makeLatest: false
+          tag: latest
+          name: Release v${{ steps.gitversion.outputs.semVer }}
+          generateReleaseNotes: true
+          body:
+            Release ${{ steps.gitversion.outputs.semVer }} of ${{ github.event.repository.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           allowUpdates: false
           skipIfReleaseExists: true
           draft: false
-          makeLatest: true
+          makeLatest: false
           tag: v${{ steps.gitversion.outputs.semVer }}
           name: Release v${{ steps.gitversion.outputs.semVer }}
           generateReleaseNotes: true
@@ -102,7 +102,7 @@ jobs:
           allowUpdates: true
           skipIfReleaseExists: false
           draft: false
-          makeLatest: false
+          makeLatest: true
           tag: latest
           name: Release v${{ steps.gitversion.outputs.semVer }}
           generateReleaseNotes: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -10098,6 +10098,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },


### PR DESCRIPTION
### **User description**
## 📑 Description
Create `latest` release 

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


___

### **Description**
- Introduced a new job to create a `latest` release in the CI workflow.
- Updated the existing release job to clarify the tagging process.
- Ensured that the new release job allows updates and does not skip if the release already exists.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Enhance CI workflow for creating releases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml
<li>Updated the release job to create a <code>latest</code> release.<br> <li> Modified the existing release job to specify the tag as <code>tag</code>.<br> <li> Added parameters for the <code>latest</code> release including <code>allowUpdates</code>, <br><code>skipIfReleaseExists</code>, and <code>draft</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/github-badges-action/pull/436/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+15/-3</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow updated to run two parallel release steps: one publishing the versioned tag and a renamed step publishing a separate "latest" release (marked as latest). Minor formatting tweaks to release body content; both releases are produced from the same workflow run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->